### PR TITLE
Add simple CLI for payee classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,15 @@ boolean parameter.
 - When `true` (default), the exported rows contain every original field along
   with additional AI columns.
 - When `false`, only the AI-related columns are included.
+
+## Command line usage
+
+After installing dependencies you can classify payee names directly from the
+terminal:
+
+```sh
+npm run classify -- "Acme LLC" "John Doe"
+```
+
+Each argument is passed to `enhancedClassifyPayeeV3` and the classification
+result is printed to stdout.

--- a/bin/classify.ts
+++ b/bin/classify.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env ts-node
+import { enhancedClassifyPayeeV3 } from '../src/lib/classification';
+
+async function main() {
+  const names = process.argv.slice(2);
+  if (names.length === 0) {
+    console.error('Usage: npm run classify -- <payee name> [additional names...]');
+    process.exit(1);
+  }
+
+  for (const name of names) {
+    const result = await enhancedClassifyPayeeV3(name);
+    console.log(`${name}: ${result.classification} (${result.confidence}%)`);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "classify": "ts-node-esm ./bin/classify.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,7 @@
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",


### PR DESCRIPTION
## Summary
- add `bin/classify.ts` utility to classify payee names
- expose `npm run classify` script with ts-node
- include ts-node dev dependency
- document the CLI usage in README

## Testing
- `npm test` *(fails: exportResultsWithOriginalDataV3 is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6859a9fa63e48331a99d3a4f2db2c86a