### PR TITLE
Improve probablepeople fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ not published to the npm registry, it is no longer listed in `package.json`.
 If you have a local build available you can install it manually and the
 classifier will load it at runtime.
 
+To install a local build, run `npm install` with the path to the generated
+`.tgz` file or project directory, e.g.
+
+```sh
+npm install ../probablepeople/dist/probablepeople-1.0.0.tgz
+```
+
+After installation the classifier will automatically use the library when
+available.
+
 API keys are stored using AES‑GCM encryption in `localStorage`, with the
 encryption key kept in `sessionStorage` for added security.
 

--- a/src/lib/classification/nlpClassification.ts
+++ b/src/lib/classification/nlpClassification.ts
@@ -8,10 +8,11 @@ import { probablepeople } from './probablepeople';
 export async function applyNLPClassification(payeeName: string): Promise<ClassificationResult | null> {
   const matchingPatterns: string[] = [];
   
-  try {
-    // Try to get detailed parsing from probablepeople
-    const [parsed, nameType] = await probablepeople.parse(payeeName);
-    
+  // Try to get detailed parsing from probablepeople
+  const parsedResult = await probablepeople.parse(payeeName);
+  if (parsedResult && Array.isArray(parsedResult)) {
+    const [parsed, nameType] = parsedResult;
+
     // If we get a confident result but it wasn't strong enough for rule-based tier
     if (nameType === 'person') {
       // Extract components that indicate a person
@@ -58,8 +59,6 @@ export async function applyNLPClassification(payeeName: string): Promise<Classif
         };
       }
     }
-  } catch (error) {
-    // Parsing failed, fall back to other NLP methods
   }
   
   const name = payeeName.trim();

--- a/src/lib/classification/probablepeople.ts
+++ b/src/lib/classification/probablepeople.ts
@@ -1,25 +1,40 @@
 
-// Fallback probablepeople module since the actual package is not available
-let loadedModule: any = null;
+// Attempt to load the optional probablepeople package when first used.
+// If the package isn't installed we fall back to a no-op implementation.
+let loadedModule: any | null | undefined = undefined;
 
 const loadProbablePeople = async () => {
-  if (loadedModule) return loadedModule;
-  
-  // Since probablepeople package is not available, use fallback only
-  console.warn('Warning: probablepeople package not available, using fallback classification only');
-  loadedModule = {
-    parse: () => {
-      throw new Error('probablepeople not available');
-    }
-  };
-  
+  if (loadedModule !== undefined) return loadedModule;
+
+  try {
+    loadedModule = await import('probablepeople');
+  } catch {
+    console.warn('Warning: probablepeople package not available, using fallback classification only');
+    loadedModule = null;
+  }
+
   return loadedModule;
 };
 
 // Export a wrapper that handles the lazy loading
 export const probablepeople = {
-  parse: async (name: string) => {
+  /**
+   * Parse a payee name using probablepeople if available.
+   *
+   * When the library is missing or parsing fails, this returns `null` or `{}`
+   * instead of throwing so callers can gracefully degrade.
+   */
+  parse: async (name: string): Promise<any> => {
     const pp = await loadProbablePeople();
-    return pp.parse(name);
+
+    if (!pp || typeof pp.parse !== 'function') {
+      return null;
+    }
+
+    try {
+      return await pp.parse(name);
+    } catch {
+      return {};
+    }
   }
 };

--- a/src/lib/classification/ruleBasedClassification.ts
+++ b/src/lib/classification/ruleBasedClassification.ts
@@ -14,10 +14,11 @@ export async function applyRuleBasedClassification(payeeName: string): Promise<C
   let isBusinessIndicator = false;
   let isIndividualIndicator = false;
 
-  // Use probablepeople to parse the name
-  try {
-    const [parsed, nameType] = await probablepeople.parse(payeeName);
-    
+  // Use probablepeople to parse the name if available
+  const parsedResult = await probablepeople.parse(payeeName);
+  if (parsedResult && Array.isArray(parsedResult)) {
+    const [parsed, nameType] = parsedResult;
+
     // If probablepeople confidently identifies the type
     if (nameType === 'person') {
       matchingRules.push("Identified as person by name structure analysis");
@@ -26,9 +27,6 @@ export async function applyRuleBasedClassification(payeeName: string): Promise<C
       matchingRules.push("Identified as corporation by name structure analysis");
       isBusinessIndicator = true;
     }
-  } catch (error) {
-    // Parsing failed, continue with other rules
-    console.log("Probablepeople parsing failed, using fallback rules");
   }
 
   // Check for legal suffixes


### PR DESCRIPTION
## Summary
- return `null` or `{}` from `probablepeople.parse` instead of throwing
- guard usages of `probablepeople.parse` in rule-based and NLP tiers
- document installing a local build of `probablepeople`

## Testing
- `npm test` *(fails: exportResultsWithOriginalDataV3 is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6859a9f7164c833181f03864d4f3527b