### PR TITLE
Remove OpenAI calls and switch to local AI heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ interface defined in `src/lib/types.ts`. Default values are provided in
 | ------ | ----------- |
 | `aiThreshold` | Minimum confidence required for rule‑based or NLP results before AI processing is triggered. |
 | `bypassRuleNLP` | Skip rule‑based and NLP checks and go straight to AI. |
-| `useEnhanced` | Enable advanced classification logic. |
 | `offlineMode` | Disable API calls and rely solely on local heuristics. |
 | `useFuzzyMatching` | Apply fuzzy name matching when deduplicating batch input. |
 | `useCacheForDuplicates` | Cache results for repeated names in a batch. |

--- a/src/components/BatchClassificationForm.tsx
+++ b/src/components/BatchClassificationForm.tsx
@@ -41,7 +41,6 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
         {
           aiThreshold: 100, // Force rule-based only
           bypassRuleNLP: false,
-          useEnhanced: true,
           offlineMode: true
         },
         originalFileData
@@ -80,7 +79,6 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
         const result = await enhancedClassifyPayeeV3(name, {
           aiThreshold: 100, // Force rule-based only
           bypassRuleNLP: false,
-          useEnhanced: true,
           offlineMode: true
         });
         

--- a/src/components/SingleClassificationForm.tsx
+++ b/src/components/SingleClassificationForm.tsx
@@ -24,7 +24,6 @@ const SingleClassificationForm = ({ onComplete }: SingleClassificationFormProps)
   const [config, setConfig] = useState<ClassificationConfig>({
     aiThreshold: 80,
     bypassRuleNLP: true,
-    useEnhanced: true,
     offlineMode: false
   });
   const { toast } = useToast();

--- a/src/lib/classification/config.ts
+++ b/src/lib/classification/config.ts
@@ -13,7 +13,6 @@ const getEnvVar = (key: string, defaultValue: string): string => {
 export const DEFAULT_CLASSIFICATION_CONFIG: ClassificationConfig = {
   aiThreshold: 75, // Default threshold - use AI when confidence is below 75%
   bypassRuleNLP: true, // Always bypass rule-based and NLP classification for accuracy
-  useEnhanced: false, // Default to NOT using enhanced classification
   offlineMode: false, // Default to online mode
   useFuzzyMatching: true, // Use fuzzy matching for better results
   useCacheForDuplicates: true // Deduplicate similar names

--- a/src/lib/classification/ruleOnlyClassification.ts
+++ b/src/lib/classification/ruleOnlyClassification.ts
@@ -10,7 +10,6 @@ export async function ruleOnlyClassification(payeeName: string): Promise<Classif
   console.log(`[RULE-ONLY-FIXED] Processing "${payeeName}" with V3 engine`);
   return await enhancedClassifyPayeeV3(payeeName, {
     offlineMode: true,
-    useEnhanced: true,
     aiThreshold: 100 // Force rule-based only
   } as any);
 }

--- a/src/lib/classification/utils.ts
+++ b/src/lib/classification/utils.ts
@@ -1,39 +1,19 @@
 
 import { ClassificationResult, ClassificationConfig } from '../types';
-import { classifyPayeeWithAI } from '../openai/singleClassification';
-import { enhancedClassifyPayeeWithAI } from '../openai/enhancedClassification';
+import { applyAIClassification } from './aiClassification';
 
 /**
- * Classify a single payee using the real OpenAI API
+ * Classify a single payee using the local AI-assisted heuristic
  */
 export async function classifyPayee(
   payeeName: string,
-  config: ClassificationConfig,
-  useEnhanced: boolean = false
+  _config: ClassificationConfig
 ): Promise<ClassificationResult> {
-  console.log(`Classifying "${payeeName}" with real OpenAI API (enhanced: ${useEnhanced})`);
-  
+  console.log(`Classifying "${payeeName}" with local AI heuristic`);
+
   try {
-    if (useEnhanced) {
-      // Use enhanced classification with caching and consensus
-      const result = await enhancedClassifyPayeeWithAI(payeeName);
-      return {
-        classification: result.classification,
-        confidence: result.confidence,
-        reasoning: result.reasoning,
-        processingTier: 'AI-Powered',
-        matchingRules: result.matchingRules
-      };
-    } else {
-      // Use standard OpenAI classification
-      const result = await classifyPayeeWithAI(payeeName);
-      return {
-        classification: result.classification,
-        confidence: result.confidence,
-        reasoning: result.reasoning,
-        processingTier: 'AI-Powered'
-      };
-    }
+    const result = await applyAIClassification(payeeName);
+    return result;
   } catch (error) {
     console.error(`Error classifying ${payeeName}:`, error);
     throw error;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,7 +67,6 @@ export interface ParsedCorporation {
 export interface ClassificationConfig {
   aiThreshold: number;
   bypassRuleNLP: boolean;
-  useEnhanced?: boolean;
   offlineMode?: boolean;
   useFuzzyMatching?: boolean;
   useCacheForDuplicates?: boolean;


### PR DESCRIPTION
## Summary
- use local applyAIClassification in utils
- remove consensus and OpenAI references in enhancedClassification modules
- simplify enhanced batch processor to use local classification
- drop `useEnhanced` option from config and types
- update React forms and docs accordingly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859ac32d08083318602c564ea3534e3