### PR TITLE
Remove obsolete exports from classificationEngine

### DIFF
--- a/src/lib/classificationEngine.ts
+++ b/src/lib/classificationEngine.ts
@@ -5,7 +5,6 @@
 export * from './classification';
 export { enhancedClassifyPayee } from './classification/enhancedClassification';
 export { enhancedProcessBatch } from './classification/enhancedBatchProcessor';
-export { consensusClassification } from './openai/enhancedClassification';
 export { getConfidenceLevel, classifyPayee } from './classification/utils';
 export { DEFAULT_CLASSIFICATION_CONFIG } from './classification/config';
 export { processBatch } from './classification/batchProcessing';
@@ -19,11 +18,6 @@ export {
   bulkKeywordExclusion 
 } from './classification/enhancedKeywordExclusion';
 
-export * from './openai/batchAPI';
-
-// Export new true batch API functionality
-export * from './openai/trueBatchAPI';
-export * from './openai/hybridBatchProcessor';
 
 // Export enhanced V2 functions
 export { enhancedClassifyPayeeV2 } from './classification/enhancedClassificationV2';


### PR DESCRIPTION
## Summary
- remove consensus and batch-related exports from `classificationEngine`
- keep re-exports of local utilities

## Testing
- `npm test` *(fails: invalid JSON syntax in data/exclusion-keywords.json)*

------
https://chatgpt.com/codex/tasks/task_b_6859ac3492ac8331bfbbd6481d2c6f50