### PR TITLE
Add business indicator check to classification fallback

### DIFF
--- a/src/lib/classification/enhancedClassificationV3.ts
+++ b/src/lib/classification/enhancedClassificationV3.ts
@@ -1,6 +1,6 @@
 
 import { ClassificationResult, ClassificationConfig } from '../types';
-import { DEFAULT_CLASSIFICATION_CONFIG } from './config';
+import { DEFAULT_CLASSIFICATION_CONFIG, INDUSTRY_IDENTIFIERS } from './config';
 import { checkKeywordExclusion } from './enhancedKeywordExclusion';
 
 // Hard-coded confidence thresholds for intelligent escalation
@@ -250,9 +250,29 @@ export async function enhancedClassifyPayeeV3(
       };
     }
 
-    // Stage 3: Conservative fallback - ALWAYS favor Individual when uncertain
+    // Stage 3: Conservative fallback with business keyword check
+    const nameUpper = payeeName.toUpperCase();
+    const industryTerms = Object.values(INDUSTRY_IDENTIFIERS).flat();
+    const hasBusinessIndicator =
+      BUSINESS_KEYWORDS.some(k => nameUpper.includes(k)) ||
+      industryTerms.some(term =>
+        nameUpper.includes(term) ||
+        (term.endsWith('AL') && nameUpper.includes(term.slice(0, -2)))
+      );
+
+    if (hasBusinessIndicator) {
+      return {
+        classification: 'Business',
+        confidence: 60,
+        reasoning: `Fallback business indicators detected. Individual: ${individualCheck.confidence}%, Business: ${businessCheck.confidence}%`,
+        processingTier: 'Rule-Based',
+        matchingRules: [...individualCheck.reasons, ...businessCheck.reasons],
+        processingMethod: 'Keyword-based fallback'
+      };
+    }
+
     const fallbackConfidence = Math.max(55, individualCheck.confidence || 55);
-    
+
     return {
       classification: 'Individual',
       confidence: fallbackConfidence,

--- a/tests/enhancedClassificationV3.test.ts
+++ b/tests/enhancedClassificationV3.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { enhancedClassifyPayeeV3 } from '@/lib/classification/enhancedClassificationV3';
+
+function mockLocalStorage() {
+  const storage = {
+    getItem: () => JSON.stringify([]),
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {}
+  } as unknown as Storage;
+  Object.defineProperty(global, 'localStorage', { value: storage, configurable: true });
+}
+
+describe('enhancedClassifyPayeeV3 fallback', () => {
+  beforeEach(() => {
+    mockLocalStorage();
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    delete (global as any).localStorage;
+  });
+
+  it('returns Business when business keywords present', async () => {
+    const result = await enhancedClassifyPayeeV3('ACME SECURITY SERVICES');
+    expect(result.classification).toBe('Business');
+    expect(result.confidence).toBeGreaterThanOrEqual(60);
+  });
+
+  it('returns Business when industry identifiers present', async () => {
+    const result = await enhancedClassifyPayeeV3('GLOBAL ELECTRIC SUPPLY');
+    expect(result.classification).toBe('Business');
+    expect(result.confidence).toBeGreaterThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Summary
- improve `enhancedClassificationV3` fallback logic
- detect business keywords and industry terms before defaulting to Individual
- add unit tests for fallback behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6859b1e9a78883319845397ba0c20749