### PR TITLE
Add industry term tests for rule-based classification

### DIFF
--- a/tests/ruleBasedClassification.test.ts
+++ b/tests/ruleBasedClassification.test.ts
@@ -25,4 +25,17 @@ describe('applyRuleBasedClassification', () => {
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Individual');
   });
+
+  it('detects business without legal suffix using industry terms', async () => {
+    const result = await applyRuleBasedClassification('NORTHWEST FIRE PROTECTION');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
+
+  it('detects business by industry term even with minimal suffix', async () => {
+    const result = await applyRuleBasedClassification('CITY ALARM CO');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
 });
+


### PR DESCRIPTION
## Summary
- extend rule-based tests to cover business names without legal suffixes
- ensure names with industry terms such as "NORTHWEST FIRE PROTECTION" and "CITY ALARM CO" classify as business

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6859b1eb17008331bf4c84b0a5820054