### PR TITLE
Add industry term business tests

### DIFF
--- a/tests/ruleBasedClassification.test.ts
+++ b/tests/ruleBasedClassification.test.ts
@@ -25,4 +25,16 @@ describe('applyRuleBasedClassification', () => {
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Individual');
   });
+
+  it('detects business by industry term without legal suffix', async () => {
+    const result = await applyRuleBasedClassification('NORTHWEST FIRE PROTECTION');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
+
+  it('detects business with legal suffix and industry term', async () => {
+    const result = await applyRuleBasedClassification('CITY ALARM CO');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for business names without legal suffixes but with industry terms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6859b1f8c31483319fd6fc34fe5c9a0b